### PR TITLE
Add argument parsing to unified demo and cover with tests

### DIFF
--- a/demo_unified_interface.py
+++ b/demo_unified_interface.py
@@ -27,6 +27,7 @@ tests can validate the individual processing stages.
 
 from __future__ import annotations
 
+import argparse
 import logging
 import math
 import random
@@ -190,4 +191,18 @@ def main(iterations: int = 5, delay: float = 0.5) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution only
-    main()
+    parser = argparse.ArgumentParser(description="Run the unified consciousness demo")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=5,
+        help="Number of iterations to run",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.5,
+        help="Delay in seconds between iterations",
+    )
+    args = parser.parse_args()
+    main(iterations=args.iterations, delay=args.delay)

--- a/tests/test_demo_unified_interface.py
+++ b/tests/test_demo_unified_interface.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import subprocess
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -34,3 +35,16 @@ def test_pipeline_state_output():
     metrics = run_demo_step()
     assert metrics.state in ConsciousnessRecognizer.STATES
     assert 0.0 <= metrics.signal_strength <= 1.0
+
+
+def test_cli_argument_parsing():
+    script = os.path.join(os.path.dirname(os.path.dirname(__file__)), "demo_unified_interface.py")
+    result = subprocess.run(
+        [sys.executable, script, "--iterations", "2", "--delay", "0"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Logging is directed to stderr; count iteration lines
+    lines = [line for line in result.stderr.splitlines() if "Signal strength" in line]
+    assert len(lines) == 2


### PR DESCRIPTION
## Summary
- allow `demo_unified_interface.py` to accept `--iterations` and `--delay` command-line flags via argparse
- add test covering command line argument parsing

## Testing
- `pytest tests/test_demo_unified_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3dcf6e118832ab51801ad7fa89a28